### PR TITLE
Add support cipublish via GitHub Actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -17,10 +17,15 @@ jobs:
     env:
       DOCKER_BUILDKIT: 1
       CI: 1
+      TIPPECANOE_VERSION: ${{ matrix.version }}
+      VARIANT: ${{ matrix.variant }}
     steps:
       - uses: actions/checkout@v2
 
       - run: ./scripts/cibuild
+
+      - run: ./scripts/cipublish
+        if: github.ref == 'refs/heads/master'
         env:
-          TIPPECANOE_VERSION: ${{ matrix.version }}
-          VARIANT: ${{ matrix.variant }}
+          QUAY_USER: ${{ secrets.QUAY_USER }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has
+            not had recent activity. It will be closed if no further activity
+            occurs.
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because
+            it has not had recent activity. It will be closed if no further
+            activity occurs.
+          days-before-stale: 60
+          days-before-close: 7
+          stale-issue-label: "stale"
+          stale-pr-label: "stale"

--- a/Dockerfile-slim.template
+++ b/Dockerfile-slim.template
@@ -1,23 +1,23 @@
-FROM debian:stable-slim
+FROM debian:stable AS builder
 
 WORKDIR /usr/local/src
 
-RUN set -ex \
-      && buildDeps=" \
+RUN apt-get update && apt-get install -yq \
       build-essential \
       libsqlite3-dev \
       libz-dev \
-      wget \
-      " \
-      && deps=" \
-      libsqlite3-0 \
-      " \
-      && apt-get update && apt-get install -y $buildDeps $deps \
-      && wget -qO- https://github.com/mapbox/tippecanoe/archive/%%TIPPECANOE_VERSION%%.tar.gz \
-      | tar xvz -C /usr/local/src \
-      && make -C /usr/local/src/tippecanoe-%%TIPPECANOE_VERSION%% \
-      && make -C /usr/local/src/tippecanoe-%%TIPPECANOE_VERSION%% install \
-      && apt-get purge -y --auto-remove $buildDeps \
-      && rm -rf /usr/local/src/tippecanoe-%%TIPPECANOE_VERSION%% /var/lib/apt/lists/*
+      wget
+
+RUN wget -qO- https://github.com/mapbox/tippecanoe/archive/%%TIPPECANOE_VERSION%%.tar.gz \
+      | tar xvz -C /usr/local/src
+RUN make -C /usr/local/src/tippecanoe-%%TIPPECANOE_VERSION%%
+RUN make -C /usr/local/src/tippecanoe-%%TIPPECANOE_VERSION%% install
+
+FROM debian:stable-slim
+
+RUN apt-get update && apt-get install -yq \
+      libsqlite3-0
+
+COPY --from=builder /usr/local/bin/tippecanoe /usr/local/bin/tippecanoe
 
 ENTRYPOINT [ "/usr/local/bin/tippecanoe" ]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # docker-tippecanoe
 
-[![CircleCI](https://circleci.com/gh/azavea/docker-tippecanoe.svg?style=svg)](https://circleci.com/gh/azavea/docker-tippecanoe)
+![](https://github.com/azavea/docker-tippecanoe/workflows/CI/badge.svg)
 
 This repository contains a collection of templated `Dockerfile` for image variants designed to support the usage of [Tippecanoe](https://github.com/mapbox/tippecanoe).
 

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 ![](https://github.com/azavea/docker-tippecanoe/workflows/CI/badge.svg)
 
-This repository contains a collection of templated `Dockerfile` for image variants designed to support the usage of [Tippecanoe](https://github.com/mapbox/tippecanoe).
+This repository contains a templated `Dockerfile` designed to support the usage of multiple [Tippecanoe](https://github.com/mapbox/tippecanoe) versions.
 
 ## Usage
 
 ### Template Variables
 
-- `TIPPECANOE_VERSION` - Tippecanoe version
-- `VARIANT` - Base container image variant
+- `TIPPECANOE_VERSION` - Tippecanoe version.
+- `VARIANT` - Base container image variant. Currently supports: `slim`.
 
 ### Testing
 

--- a/scripts/cibuild
+++ b/scripts/cibuild
@@ -22,7 +22,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             "Dockerfile-$VARIANT.template" >Dockerfile
 
         docker \
-            build -t "quay.io/azavea/tippecanoe:$TIPPECANOE_VERSION-$VARIANT" .
+            build -t "quay.io/azavea/tippecanoe:${TIPPECANOE_VERSION%.*}-$VARIANT" .
 
         scripts/test
 

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -18,6 +18,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             login -u "${QUAY_USER}" -p "${QUAY_PASSWORD}" quay.io
 
         docker \
-            push "quay.io/azavea/tippecanoe:$TIPPECANOE_VERSION-$VARIANT"
+            push "quay.io/azavea/tippecanoe:${TIPPECANOE_VERSION%.*}-$VARIANT"
     fi
 fi

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+set -u
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Publish container images built from templates.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        docker \
+            login -u "${QUAY_USER}" -p "${QUAY_PASSWORD}" quay.io
+
+        docker \
+            push "quay.io/azavea/tippecanoe:$TIPPECANOE_VERSION-$VARIANT"
+    fi
+fi

--- a/scripts/test
+++ b/scripts/test
@@ -19,6 +19,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         usage
     else
         docker \
-            run --rm "quay.io/azavea/tippecanoe:$TIPPECANOE_VERSION-$VARIANT" --version
+            run --rm "quay.io/azavea/tippecanoe:${TIPPECANOE_VERSION%.*}-$VARIANT" --version
     fi
 fi


### PR DESCRIPTION
Extend the existing GitHub Actions configuration to support `cipublish`, but only when the `master` branch has triggered the build. In addition:

- Push matrix sourced environment variables up to the job level
- Add a GitHub Actions specific README badge
- Make use of secrets to set and retrieve Quay credentials

Also, add support for `actions/stale`.

---

### Testing

- Review the [build log](https://github.com/azavea/docker-tippecanoe/runs/587791471?check_suite_focus=true) that used a temporary conditional for `cipublish` so that it would execute the entire workflow
- Ensure that the image pushed to Quay by the workflow is functional

```console
$ docker run --rm quay.io/azavea/tippecanoe:1.35.0-slim --version
Unable to find image 'quay.io/azavea/tippecanoe:1.35.0-slim' locally
1.35.0-slim: Pulling from azavea/tippecanoe
5d23f9193e1f: Pull complete
4f4fb700ef54: Pull complete
91843cb4e626: Pull complete
Digest: sha256:b7722ea5be0fa7bf95c0c0c392fb9497faf79d276fa25486359d41e1dde93f80
Status: Downloaded newer image for quay.io/azavea/tippecanoe:1.35.0-slim
tippecanoe v1.35.0
```

- Review the repository contents outside of this PR, because the other parts haven't been reviewed
- Help come up with repository topics to make repository more discoverable