### PR TITLE
Remove CI variable

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -16,7 +16,6 @@ jobs:
         variant: ["slim"]
     env:
       DOCKER_BUILDKIT: 1
-      CI: 1
       TIPPECANOE_VERSION: ${{ matrix.version }}
       VARIANT: ${{ matrix.variant }}
     steps:


### PR DESCRIPTION
As discussed in https://github.com/azavea/docker-django/pull/114#discussion_r447727937, this variable is set to `true` by default: https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables